### PR TITLE
test: refactor CLI tests to minimize excessive mocking (LIB-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Token solo debe generarse después de todas las validaciones
   - Previene ataque: commit abort → token orphan → reuse with --no-verify
 
+### Fixed
+- 🧪 **Refactor CLI Tests to Minimize Excessive Mocking (LIB-19)** - Post-Mortem Prevention Measure
+  - Eliminated excessive mocking of `instalar_hook` function in 5 tests
+  - Tests now use REAL hook installation and validate actual filesystem state
+  - Validates hooks exist on filesystem with correct content
+  - Validates hooks contain correct module imports (`ci_guardian.hooks.{modulo_nombre}`)
+  - Validates hook permissions (755 on Linux) and .bat extension on Windows
+  - Tests now would have caught the v0.1.0 bug (missing pre_push.py module)
+  - Only mocks external I/O (Path.cwd), not internal logic
+  - All 358 tests still pass, coverage maintained at 73%
+  - Refactored tests:
+    - `test_debe_instalar_hooks_exitosamente_cuando_esta_en_repo_git`
+    - `test_debe_rechazar_instalacion_cuando_hooks_ya_existen`
+    - `test_debe_sobrescribir_hooks_cuando_se_usa_flag_force`
+    - `test_debe_instalar_hooks_con_permisos_755_en_linux`
+    - `test_debe_instalar_hooks_bat_en_windows`
+
 ### Planned
 - LIB-2: Virtual Environment Manager - Detección/gestión de entornos virtuales (COMPLETED, needs integration)
 - LIB-5: Security Audit - Integración con Bandit y Safety


### PR DESCRIPTION
## Why
Implements post-mortem prevention measure from v0.1.0 bug analysis. Excessive mocking in tests allowed a critical bug (missing `pre_push.py` module) to pass all tests and reach production. This refactoring ensures tests validate actual implementation behavior.

## What
Refactored 5 CLI tests to eliminate excessive mocking of `instalar_hook` function:

1. **test_debe_instalar_hooks_exitosamente_cuando_esta_en_repo_git**
   - Before: Mocked `instalar_hook`, only checked call count
   - After: Uses real implementation, validates hooks exist on filesystem with correct module imports

2. **test_debe_rechazar_instalacion_cuando_hooks_ya_existen**
   - Before: Mocked `instalar_hook.side_effect = FileExistsError`
   - After: Creates real hooks, validates real FileExistsError and no overwrite

3. **test_debe_sobrescribir_hooks_cuando_se_usa_flag_force**
   - Before: Mocked both `desinstalar_hook` and `instalar_hook`
   - After: Uses real implementations, validates actual hook replacement on filesystem

4. **test_debe_instalar_hooks_con_permisos_755_en_linux**
   - Before: Mocked `instalar_hook`, only checked it was called
   - After: Uses real implementation, validates actual 755 permissions on filesystem

5. **test_debe_instalar_hooks_bat_en_windows**
   - Before: Mocked `instalar_hook`, only checked it was called
   - After: Uses real implementation, validates .bat extension and @echo off content

## How
- Only mocks external I/O (`Path.cwd()`) to control test context
- Uses real `instalar_hook` implementation to install hooks
- Validates filesystem state after operations:
  - Hook files exist at correct paths
  - Hook content contains `CI-GUARDIAN-HOOK` marker
  - Hook content executes correct module (`ci_guardian.hooks.{modulo_nombre}`)
  - Permissions are correct (755 on Linux)
  - Extension is correct (.bat on Windows)
- Tests now validate the **contract** (what hooks should contain) not just the **call** (that function was invoked)

## Testing
- ✅ All 358 tests pass (35 CLI tests + 323 other tests)
- ✅ Coverage maintained at 73% (same as before)
- ✅ Pre-commit hooks pass (ruff, black, bandit, mypy)
- ✅ Tests would now catch v0.1.0 bug:
  - If `pre_push.py` module doesn't exist, hook content won't contain correct import
  - Test will fail when validating hook content

## Impact
These refactored tests implement the 4th prevention rule from LIB-22 post-mortem:
> ✅ MINIMIZAR mocks en tests críticos - Mockear solo I/O externo (subprocess, filesystem, git), NO lógica interna

Tests are now more robust and will catch integration issues that excessive mocking hides.

## Related
- Closes LIB-19
- Related to LIB-22 (Post-Mortem Analysis)
- Addresses v0.1.0 bug prevention