### PR TITLE
feat(cli): add runtime module validation before installing hooks (LIB-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- 🛡️ **Runtime Module Validation (LIB-21)** - Fail-Fast Prevention
+  - CLI validates hook modules exist BEFORE installing them
+  - New `_validar_hook_existe()` function uses `import_module()`
+  - Called in `install` command for each hook before installation
+  - Fails with clear error message if module missing
+  - Error message includes GitHub issue reporting link
+  - Would have prevented v0.1.0 bug at install time instead of runtime
+  - Tests validate function behavior with valid and invalid hooks
+  - 2 new tests: valid hooks pass, invalid hooks fail with clear message
+
 - ✅ **Module Validation Test (LIB-16)** - Post-Mortem Prevention Measure
   - New test validates HOOKS_ESPERADOS has corresponding modules
   - Test imports each module using `import_module()`


### PR DESCRIPTION
## Why
v0.1.0 bug installed broken hooks because CLI never validated that hook modules existed before installation. Users got `ModuleNotFoundError` during `git push` instead of clear error during `ci-guardian install`.

## What
Added fail-fast validation that checks hook modules exist BEFORE installing:
- New `_validar_hook_existe()` function in `cli.py`
- Called in `install` command for each hook before installation
- Validates module using `import_module()`
- Fails with clear error message if module missing

## How
Function flow:
1. Convert hook name to module name (kebab-case → snake_case)
2. Build module path: `ci_guardian.hooks.{modulo_nombre}`
3. Attempt `import_module(modulo_path)`
4. If fails: raise `ValueError` with clear message

Error message includes:
- Which hook can't be installed
- Expected module path
- GitHub issue reporting link

Integration in install command:
```python
for hook_name in HOOKS_ESPERADOS:
    # ✅ Validate module exists BEFORE installing
    _validar_hook_existe(hook_name)  # Would have failed in v0.1.0
    
    contenido = _obtener_contenido_hook(hook_name)
    instalar_hook(repo_path, hook_name, contenido)
```

## Testing
✅ 2 new tests:
- `test_validar_hook_existe_debe_pasar_con_hooks_validos`: validates current hooks pass
- `test_validar_hook_existe_debe_fallar_con_hook_inexistente`: validates error message for missing module (simulates v0.1.0 bug)

✅ All existing tests pass (361 tests total now)

## Impact
**Before (v0.1.0)**:
```bash
$ ci-guardian install
✓ 4 hooks instalados exitosamente  # Lies! pre-push hook is broken

$ git push
ModuleNotFoundError: No module named 'ci_guardian.hooks.pre_push'
# Error at runtime, user confused
```

**After (this PR)**:
```bash
$ ci-guardian install
Error: No se puede instalar el hook 'pre-push': el módulo 'ci_guardian.hooks.pre_push' no existe.
Esto es un bug de CI Guardian. Por favor reporta en: https://github.com/jarkillo/ci-guardian/issues
# Clear error at install time, user knows it's a bug
```

This implements fail-fast principle: detect problems early, fail with clear messages.

## Related
- Closes LIB-21
- Complements LIB-16 (test-time validation)
- Prevention measure from v0.1.0 post-mortem