### PR TITLE
refactor(validators): centralize path traversal validation (LIB-26)

### DIFF
--- a/src/ci_guardian/cli.py
+++ b/src/ci_guardian/cli.py
@@ -31,20 +31,6 @@ HOOKS_ESPERADOS = ["pre-commit", "commit-msg", "post-commit", "pre-push"]
 DIRECTORIOS_EXCLUIDOS = {"venv", ".venv", "env", ".env", ".git", "__pycache__", "build", "dist"}
 
 
-def _validar_path_traversal(path_str: str) -> None:
-    """
-    Valida que un path no contenga path traversal (..).
-
-    Args:
-        path_str: String del path a validar
-
-    Raises:
-        ValueError: Si se detecta path traversal
-    """
-    if ".." in path_str:
-        raise ValueError("Path traversal detectado: ruta inválida")
-
-
 def _obtener_repo_path(repo: str) -> Path:
     """
     Obtiene y valida el path del repositorio.
@@ -58,8 +44,10 @@ def _obtener_repo_path(repo: str) -> Path:
     Raises:
         ValueError: Si se detecta path traversal o no es repo git
     """
-    # Validar path traversal
-    _validar_path_traversal(repo)
+    # Validar path traversal usando función centralizada
+    from ci_guardian.validators.common import validar_path_seguro
+
+    validar_path_seguro(repo, "repositorio")
 
     # Resolver path
     repo_path = Path.cwd() if repo == "." else Path(repo).resolve()

--- a/src/ci_guardian/validators/code_quality.py
+++ b/src/ci_guardian/validators/code_quality.py
@@ -23,13 +23,12 @@ def _filtrar_archivos_python(archivos: list[Path]) -> list[Path]:
     Raises:
         ValueError: Si se detecta path traversal (..)
     """
+    from ci_guardian.validators.common import validar_path_seguro
+
     archivos_validos = []
     for archivo in archivos:
-        # Rechazar path traversal (seguridad crítica)
-        if ".." in str(archivo):
-            raise ValueError(
-                f"path traversal detectado en '{archivo}': ruta inválida fuera del proyecto"
-            )
+        # Rechazar path traversal (seguridad crítica) usando función centralizada
+        validar_path_seguro(archivo, "archivo")
 
         # Solo archivos .py
         if archivo.suffix != ".py":

--- a/src/ci_guardian/validators/common.py
+++ b/src/ci_guardian/validators/common.py
@@ -1,0 +1,68 @@
+"""Utilidades comunes para validadores de CI Guardian.
+
+Este módulo proporciona funciones reutilizables para validación de seguridad,
+principalmente la validación centralizada de path traversal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def validar_path_seguro(path: Path | str, nombre_contexto: str = "path") -> Path:
+    """Valida que un path sea seguro y no contenga path traversal.
+
+    Verifica que el path no contenga ".." que podría permitir acceso a
+    archivos fuera del directorio del proyecto (path traversal attack).
+
+    Args:
+        path: Path a validar (Path o str)
+        nombre_contexto: Nombre para mensaje de error (ej: "archivo", "directorio", "repositorio")
+
+    Returns:
+        Path validado como objeto Path
+
+    Raises:
+        ValueError: Si se detecta path traversal (".." en la ruta)
+
+    Examples:
+        >>> validar_path_seguro("src/main.py")
+        Path('src/main.py')
+
+        >>> validar_path_seguro("../../etc/passwd")
+        Traceback (most recent call last):
+            ...
+        ValueError: Path traversal detectado en path: ../../etc/passwd
+
+        >>> validar_path_seguro("../malicious", "archivo")
+        Traceback (most recent call last):
+            ...
+        ValueError: Path traversal detectado en archivo: ../malicious
+
+    Security Note:
+        Esta función implementa una validación básica pero efectiva contra
+        path traversal. Rechaza cualquier path que contenga ".." para prevenir
+        acceso a directorios padre, incluso si ".." está en medio de la ruta
+        (ej: "foo/../bar").
+
+        Futuras mejoras podrían incluir:
+        - Validación de symlinks maliciosos
+        - Validación de UNC paths en Windows
+        - Resolución de paths y verificación de que estén dentro del repo
+    """
+    # Convertir a Path si es string
+    path_obj = Path(path) if isinstance(path, str) else path
+
+    # Convertir a string para validación
+    path_str = str(path_obj)
+
+    # Validar path traversal básico
+    # IMPORTANTE: Cualquier ocurrencia de ".." es sospechosa y se rechaza
+    # Esto incluye: "../foo", "foo/../bar", "foo/..", etc.
+    if ".." in path_str:
+        raise ValueError(
+            f"Path traversal detectado en {nombre_contexto}: {path_str}. "
+            f"ruta inválida fuera del proyecto"
+        )
+
+    return path_obj

--- a/src/ci_guardian/validators/security.py
+++ b/src/ci_guardian/validators/security.py
@@ -33,9 +33,10 @@ def ejecutar_bandit(directorio: Path, formato: str = "json") -> tuple[bool, dict
     if formato not in FORMATOS_PERMITIDOS:
         raise ValueError(f"Formato inválido: {formato}. Formatos permitidos: {FORMATOS_PERMITIDOS}")
 
-    # Validación de seguridad: prevenir path traversal
-    if ".." in str(directorio):
-        raise ValueError("Path traversal detectado: ruta inválida fuera del proyecto")
+    # Validación de seguridad: prevenir path traversal (usando función centralizada)
+    from ci_guardian.validators.common import validar_path_seguro
+
+    validar_path_seguro(directorio, "directorio")
 
     # Validar que el directorio existe
     if not directorio.exists():

--- a/tests/unit/test_validators_common.py
+++ b/tests/unit/test_validators_common.py
@@ -1,0 +1,306 @@
+"""Tests para el módulo validators/common.py de CI Guardian.
+
+Este módulo implementa tests para utilidades comunes de validadores,
+principalmente la validación centralizada de path traversal.
+Los tests se escriben PRIMERO siguiendo TDD estricto (fase RED).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestValidarPathSeguro:
+    """Tests para la función validar_path_seguro()."""
+
+    def test_debe_aceptar_path_normal_relativo(self) -> None:
+        """Debe aceptar paths relativos normales sin '..'."""
+        # Arrange & Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro("src/main.py")
+
+        # Assert
+        assert path_resultado == Path("src/main.py")
+
+    def test_debe_aceptar_path_normal_absoluto(self, tmp_path: Path) -> None:
+        """Debe aceptar paths absolutos sin '..'."""
+        # Arrange
+        path_absoluto = tmp_path / "proyecto" / "archivo.py"
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(str(path_absoluto))
+
+        # Assert
+        assert path_resultado == path_absoluto
+
+    def test_debe_rechazar_path_con_doble_punto_simple(self) -> None:
+        """Debe rechazar path con '..' simple."""
+        # Arrange & Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro("../etc/passwd")
+
+    def test_debe_rechazar_path_con_doble_punto_multiple(self) -> None:
+        """Debe rechazar path con múltiples '..'."""
+        # Arrange & Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro("../../etc/passwd")
+
+    def test_debe_rechazar_path_con_doble_punto_intermedio(self) -> None:
+        """Debe rechazar path con '..' en medio de la ruta."""
+        # Arrange & Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro("foo/../bar/baz.py")
+
+    def test_debe_rechazar_path_con_doble_punto_al_final(self) -> None:
+        """Debe rechazar path que termina con '..'."""
+        # Arrange & Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro("foo/bar/..")
+
+    def test_debe_aceptar_path_object_en_lugar_de_string(self) -> None:
+        """Debe aceptar objetos Path además de strings."""
+        # Arrange
+        path_obj = Path("src") / "archivo.py"
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(path_obj)
+
+        # Assert
+        assert path_resultado == path_obj
+
+    def test_debe_rechazar_path_object_con_doble_punto(self) -> None:
+        """Debe rechazar objetos Path que contengan '..'."""
+        # Arrange
+        path_obj = Path("..") / "etc" / "passwd"
+
+        # Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro(path_obj)
+
+    def test_mensaje_error_debe_incluir_nombre_contexto_por_defecto(self) -> None:
+        """El mensaje de error debe incluir 'path' por defecto."""
+        # Arrange & Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="path.*\\.\\."):
+            validar_path_seguro("../malicious")
+
+    def test_mensaje_error_debe_incluir_nombre_contexto_personalizado(
+        self,
+    ) -> None:
+        """El mensaje de error debe incluir el contexto personalizado."""
+        # Arrange & Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="archivo.*\\.\\."):
+            validar_path_seguro("../malicious", nombre_contexto="archivo")
+
+    def test_debe_incluir_path_en_mensaje_de_error(self) -> None:
+        """El mensaje de error debe mostrar el path problemático."""
+        # Arrange
+        path_malicioso = "../../etc/shadow"
+
+        # Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match=path_malicioso):
+            validar_path_seguro(path_malicioso)
+
+    def test_debe_manejar_paths_vacios(self) -> None:
+        """Debe manejar gracefully paths vacíos."""
+        # Arrange & Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro("")
+
+        # Assert - path vacío es técnicamente válido (current dir)
+        assert path_resultado == Path("")
+
+    def test_debe_manejar_punto_simple_como_directorio_actual(self) -> None:
+        """Debe aceptar '.' como directorio actual."""
+        # Arrange & Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(".")
+
+        # Assert
+        assert path_resultado == Path(".")
+
+    def test_debe_aceptar_archivos_con_doble_punto_en_nombre(self) -> None:
+        """Debe aceptar archivos con '..' literales en el nombre (no path sep)."""
+        # Arrange - algunos archivos pueden tener .. en su nombre
+        # Ej: "version..backup.txt" (aunque inusual, es válido)
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        # Este caso es edge - si el archivo se llama literalmente "test..py"
+        # sin separadores de directorio, no es path traversal
+        # Sin embargo, nuestra implementación simple detectará ".." en el string
+        # Esto es CORRECTO desde una perspectiva de seguridad (better safe than sorry)
+
+        # Por ahora, el test verifica que ".." se rechaza siempre
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro("test..py")
+
+    def test_debe_retornar_path_object_siempre(self) -> None:
+        """Debe retornar siempre un objeto Path, nunca string."""
+        # Arrange & Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        resultado_desde_str = validar_path_seguro("src/main.py")
+        resultado_desde_path = validar_path_seguro(Path("src/main.py"))
+
+        # Assert
+        assert isinstance(resultado_desde_str, Path)
+        assert isinstance(resultado_desde_path, Path)
+
+
+class TestValidarPathSeguroCompatibilidad:
+    """Tests de compatibilidad con código existente."""
+
+    def test_compatibilidad_con_cli_validar_path_traversal(self) -> None:
+        """Debe ser compatible con uso actual en cli.py."""
+        # Arrange - simular uso actual en cli.py:_validar_path_traversal
+
+        # Act & Assert - debe rechazar lo mismo que la función original
+        from ci_guardian.validators.common import validar_path_seguro
+
+        # Caso que cli.py rechaza: paths con ".."
+        with pytest.raises(ValueError):
+            validar_path_seguro("../malicious", "repositorio")
+
+        # Caso que cli.py acepta: paths sin ".."
+        path_valido = validar_path_seguro("./mi-proyecto")
+        assert path_valido == Path("./mi-proyecto")
+
+    def test_compatibilidad_con_code_quality_validacion_archivos(
+        self,
+    ) -> None:
+        """Debe ser compatible con validación en code_quality.py."""
+        # Arrange - simular uso actual en code_quality.py:28-32
+        archivos = [
+            Path("src/main.py"),
+            Path("tests/test_foo.py"),
+            Path("README.md"),
+        ]
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        # Validar todos los archivos
+        archivos_seguros = [validar_path_seguro(str(f), "archivo") for f in archivos]
+
+        # Assert
+        assert len(archivos_seguros) == 3
+        assert all(isinstance(p, Path) for p in archivos_seguros)
+
+    def test_compatibilidad_con_code_quality_rechazar_traversal(self) -> None:
+        """Debe rechazar path traversal igual que code_quality.py."""
+        # Arrange - archivo malicioso con path traversal
+        archivo_malicioso = Path("../../../etc/passwd")
+
+        # Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="(?i)path traversal detectado.*ruta inválida"):
+            validar_path_seguro(str(archivo_malicioso), "archivo")
+
+    def test_compatibilidad_con_security_validacion_directorio(self) -> None:
+        """Debe ser compatible con validación en security.py."""
+        # Arrange - simular uso actual en security.py:37-38
+
+        # Act & Assert - debe rechazar lo mismo
+        from ci_guardian.validators.common import validar_path_seguro
+
+        # Directorio malicioso
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro("../malicious", "directorio")
+
+        # Directorio válido
+        directorio_valido = validar_path_seguro("src")
+        assert directorio_valido == Path("src")
+
+
+class TestValidarPathSeguroEdgeCases:
+    """Tests de casos edge y situaciones especiales."""
+
+    def test_debe_manejar_paths_windows_con_backslash(self) -> None:
+        """Debe manejar paths de Windows con backslashes."""
+        # Arrange
+        path_windows = "src\\main.py"
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(path_windows)
+
+        # Assert - debe aceptar backslashes normales
+        assert path_resultado == Path(path_windows)
+
+    def test_debe_rechazar_path_windows_con_doble_punto(self) -> None:
+        """Debe rechazar paths de Windows con path traversal."""
+        # Arrange
+        path_windows_malicioso = "..\\windows\\system32"
+
+        # Act & Assert
+        from ci_guardian.validators.common import validar_path_seguro
+
+        with pytest.raises(ValueError, match="Path traversal detectado"):
+            validar_path_seguro(path_windows_malicioso)
+
+    def test_debe_manejar_paths_muy_largos(self) -> None:
+        """Debe manejar paths muy largos sin problemas de performance."""
+        # Arrange - path muy largo pero sin ".."
+        path_largo = "/".join([f"dir{i}" for i in range(100)]) + "/archivo.py"
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(path_largo)
+
+        # Assert
+        assert path_resultado == Path(path_largo)
+
+    def test_debe_manejar_paths_con_espacios(self) -> None:
+        """Debe manejar paths con espacios en nombres."""
+        # Arrange
+        path_con_espacios = "Mi Proyecto/archivo con espacios.py"
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(path_con_espacios)
+
+        # Assert
+        assert path_resultado == Path(path_con_espacios)
+
+    def test_debe_manejar_paths_con_caracteres_unicode(self) -> None:
+        """Debe manejar paths con caracteres Unicode."""
+        # Arrange
+        path_unicode = "código/archivo_español.py"
+
+        # Act
+        from ci_guardian.validators.common import validar_path_seguro
+
+        path_resultado = validar_path_seguro(path_unicode)
+
+        # Assert
+        assert path_resultado == Path(path_unicode)


### PR DESCRIPTION
## Why
Path traversal validation was duplicated in 3 locations across the codebase:
- `cli.py`: Had its own `_validar_path_traversal()` function (13 lines)
- `code_quality.py`: Inline check with `if ".." in str(archivo):`
- `security.py`: Inline check with `if ".." in str(directorio):`

This violates DRY principle and makes maintenance harder. Changes to validation logic would require updating 3 places.

## What
Created centralized path traversal validation module:
- New module: `src/ci_guardian/validators/common.py`
- Function: `validar_path_seguro(path, nombre_contexto="path") -> Path`
- Migrated all 3 locations to use the centralized function
- Eliminated code duplication (~18 lines total)

## How
**TDD Approach (RED → GREEN → REFACTOR)**:

**RED Phase**:
- Created `tests/unit/test_validators_common.py` with 24 tests
- All tests failed with `ModuleNotFoundError` (expected)

**GREEN Phase**:
- Implemented `validators/common.py` with `validar_path_seguro()`
- Function validates that path doesn't contain ".." (path traversal)
- Accepts both `str` and `Path` objects
- Returns `Path` object
- Customizable error messages with `nombre_contexto` parameter
- All 24 tests pass

**REFACTOR Phase**:
- Migrated `cli.py`: Removed `_validar_path_traversal()`, use centralized version
- Migrated `code_quality.py`: Replaced inline check with function call
- Migrated `security.py`: Replaced inline check with function call

## Testing
✅ **397/397 tests pass** (10 skipped)
✅ **100% coverage** on `validators/common.py` module
✅ **76% total coverage** (above 75% threshold)

**Test categories**:
- Happy paths (normal relative/absolute paths)
- Rejection cases (various ".." patterns)
- Edge cases (empty paths, Windows paths, Unicode, etc.)
- Compatibility tests with existing code
- Cross-platform tests (Linux/Windows)

**Security validation**:
- ✅ Pre-commit hooks pass (Ruff, Black, Bandit, MyPy)
- ✅ No new security warnings

## Related
Closes LIB-26

**Follow-up opportunities** (not in this PR):
- LIB-27: Centralize Python file filtering logic
- Consider validating symlinks in future version