### PR TITLE
fix(ci): Black-compatible test file in smoke tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,8 +129,10 @@ jobs:
           source /tmp/smoke-venv/bin/activate
           cd /tmp/smoke-test-repo
 
-          # Crear archivo Python de prueba
-          echo "print('smoke test')" > test.py
+          # Crear archivo Python de prueba (formato compatible con Black)
+          cat > test.py << 'EOF'
+          print("smoke test")
+          EOF
           git add test.py
 
           # Ejecutar commit (trigger pre-commit, commit-msg, post-commit hooks)


### PR DESCRIPTION
## Problem

The smoke test in the v0.2.0 release workflow is failing because the test.py file created uses single quotes:
```python
print('smoke test')
```

Black prefers double quotes and rejects this format.

## Solution

Changed the smoke test to create a properly formatted file using cat with heredoc:
```python
print("smoke test")
```

## Changes

- ✅ Use double quotes (Black's preference)
- ✅ Use cat with heredoc for cleaner syntax

## Testing

After merge:
1. Delete v0.2.0 release and tag
2. Recreate v0.2.0 release
3. Smoke tests should pass

## Related

Fixes smoke test failure in v0.2.0 release workflow (run #19069981843)

🤖 Generated with [Claude Code](https://claude.com/claude-code)