### PR TITLE
fix(ci): Skip tests in smoke test pre-push hook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,8 +154,9 @@ jobs:
 
             # Ejecutar push (trigger pre-push hook)
             # Usa HEAD para pushear la rama actual (main)
-            git push origin HEAD
-            echo "✅ Push workflow passed (pre-push hook executed)"
+            # Skip tests porque pytest no está instalado en venv limpio
+            CI_GUARDIAN_SKIP_TESTS=1 git push origin HEAD
+            echo "✅ Push workflow passed (pre-push hook executed with CI_GUARDIAN_SKIP_TESTS=1)"
           else
             echo "ℹ️  No pre-push hook installed, skipping push test"
             echo "✅ Push workflow test skipped (hook not present)"


### PR DESCRIPTION
## Problem

The pre-push hook executes pytest to run tests before allowing push. However, in the smoke test environment (clean venv with only ci-guardian installed), pytest is not available, causing the smoke test to fail:

```
✗ pytest no está instalado. Instala con: pip install pytest
❌ Algunas validaciones fallaron. Push bloqueado.
```

## Solution

Added `CI_GUARDIAN_SKIP_TESTS=1` environment variable before `git push` in the smoke test workflow. This is the documented way to skip test execution in the pre-push hook.

## Why This Is Correct

The smoke tests already validate:
1. ✅ Hook installation (100% status)
2. ✅ Commit workflow (pre-commit, commit-msg, post-commit)  
3. ✅ Pre-push hook is triggered and executes

Testing pytest separately in smoke tests is:
- Redundant (we test hooks work, not pytest)
- Requires unnecessary test dependencies
- Not the purpose of smoke tests (validate install, not run full test suite)

## Changes

- Added `CI_GUARDIAN_SKIP_TESTS=1` before `git push origin HEAD`
- Updated success message to indicate skip was used
- Added comment explaining why skip is needed

## Testing

After merge, re-release v0.2.0:
1. Delete release and tag
2. Recreate tag and release
3. Smoke tests should pass ✅

## Related

- Fixes smoke test failure in v0.2.0 release (run #19070630212)
- Follows up PR #36 (Black format fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)