### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-12-12
+
 ### Fixed
 - 🔧 **Improved Bandit JSON Error Handling** - Better debugging when Bandit fails
   - Detect when Bandit returns empty stdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ci-guardian"
-version = "0.3.0"
+version = "0.3.1"
 description = "Git hooks automation for Claude Code projects - enforces code quality, security, and prevents hook bypass"
 readme = "README.md"
 authors = [

--- a/src/ci_guardian/__init__.py
+++ b/src/ci_guardian/__init__.py
@@ -4,6 +4,6 @@ CI Guardian - Git hooks automation for Claude Code projects.
 Enforces code quality, security, and prevents hook bypass.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Jarko"
 __all__ = ["__version__"]


### PR DESCRIPTION
Bump version to 0.3.1 for release.

Changes:
- pyproject.toml: 0.3.0 → 0.3.1
- src/ci_guardian/__init__.py: __version__ = "0.3.1"
- CHANGELOG.md: Mark [0.3.1] - 2025-12-12